### PR TITLE
Add synchronize event to PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: PR Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   review:


### PR DESCRIPTION
The workflow now triggers on both 'opened' and 'synchronize' events, ensuring that Claude re-reviews the PR when new commits are pushed. This restores the functionality from the previous claude-code-review.yml workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the GitHub Actions workflow to ensure reviews re-run on new commits.
> 
> - In `.github/workflows/claude-review.yml`, adds `synchronize` to `pull_request.types` (now `opened, synchronize`) so the CLA review action reruns on updates to the PR
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed1967860e5936c5cac814e76002aed9ddae0a36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->