### PR TITLE
Add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,10 @@ Blog posts can have dynamically generated OG images:
 - The site uses IANA timezone format (default: `America/New_York`)
 - Static assets go in `public/` directory
 - Custom Shiki transformers support filename display, syntax highlighting, and diffs
+
+## Cursor Cloud specific instructions
+
+- Node 22+ and `pnpm` are preinstalled; dependencies are refreshed automatically on startup. See "Essential Commands" above for lint/build/dev commands.
+- Dev server: `pnpm run dev --host 0.0.0.0` serves on `http://localhost:4321/`. New/edited posts in `src/data/blog/*.md` hot-reload automatically.
+- `pnpm install` prints a warning that build scripts for `esbuild` and `sharp` are ignored. This is expected and does NOT need fixing — `pnpm run build` (which uses `sharp`/`resvg` for OG images) and `pnpm run dev` both succeed regardless. Do not run the interactive `pnpm approve-builds`.
+- `pnpm run lint` currently reports 5 pre-existing errors in `src/constants.ts` (unused `Icon*` imports left from commented-out social/share links). These are unrelated to environment setup; do not "fix" them unless that is the actual task.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this Astro blog. Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing non-obvious startup/run caveats discovered during setup.

## What was verified

- `pnpm install --frozen-lockfile` installs cleanly (the ignored `esbuild`/`sharp` build-script warning is benign).
- `pnpm run lint` runs; reports 5 pre-existing errors in `src/constants.ts` (unused `Icon*` imports from commented-out social links) unrelated to setup.
- `pnpm run build` succeeds end-to-end (astro check + build + pagefind index).
- `pnpm run dev` serves the blog at `http://localhost:4321/`.
- Hello-world check: created a temporary blog post, confirmed it rendered via the dev server with hot-reload, then removed it.

## Notes

- Update script for future runs: `pnpm install --frozen-lockfile`.
- No application source code changed; only `AGENTS.md` documentation was added.

[astro_blog_dev_walkthrough.mp4](https://cursor.com/agents/bc-f1e62d31-3219-48b5-9e30-98a60db20f37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_blog_dev_walkthrough.mp4)
[Astro blog homepage](https://cursor.com/agents/bc-f1e62d31-3219-48b5-9e30-98a60db20f37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1e62d31-3219-48b5-9e30-98a60db20f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1e62d31-3219-48b5-9e30-98a60db20f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

