### PR TITLE
Center and constrain "View all posts" area on index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,7 +78,7 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
       )
     }
 
-    <div class="px-6 pb-16">
+    <div class="mx-auto max-w-app px-6 pb-16">
       <LinkButton
         href="/posts/"
         class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-accent"


### PR DESCRIPTION
### Motivation
- Constrain the width and center the "View all posts" link so it aligns with the main content layout. 

### Description
- Replace the unbounded wrapper `div` class `px-6 pb-16` with `mx-auto max-w-app px-6 pb-16` in `src/pages/index.astro` to center and limit its width.

### Testing
- Ran `npm run build` and a local preview with `npm run start` to verify the layout update and confirm the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a403f2aab24832c8f0c5cc3b1c28739)