### PR TITLE
[codex] Add homepage graphic and smooth page transitions

### DIFF
--- a/src/components/BackToTopButton.astro
+++ b/src/components/BackToTopButton.astro
@@ -24,22 +24,32 @@ import IconArrowNarrowUp from "@/assets/icons/IconArrowNarrowUp.svg";
 
 <script is:inline data-astro-rerun>
   function backToTop() {
+    const controller = new AbortController();
+    const { signal } = controller;
     const rootElement = document.documentElement;
     const btnContainer = document.querySelector("#btt-btn-container");
     const backToTopBtn = document.querySelector("[data-button='back-to-top']");
 
     if (!rootElement || !btnContainer || !backToTopBtn) return;
 
-    backToTopBtn.addEventListener("click", () => {
-      document.body.scrollTop = 0;
-      document.documentElement.scrollTop = 0;
+    document.addEventListener("astro:before-swap", () => controller.abort(), {
+      once: true,
     });
+
+    backToTopBtn.addEventListener(
+      "click",
+      () => {
+        document.body.scrollTop = 0;
+        document.documentElement.scrollTop = 0;
+      },
+      { signal },
+    );
 
     let lastVisible = null;
     function handleScroll() {
       const scrollTotal = rootElement.scrollHeight - rootElement.clientHeight;
       const scrollTop = rootElement.scrollTop;
-      const isVisible = scrollTop / scrollTotal > 0.3;
+      const isVisible = scrollTotal > 0 && scrollTop / scrollTotal > 0.3;
 
       if (isVisible !== lastVisible) {
         btnContainer.classList.toggle("opacity-100", isVisible);
@@ -51,15 +61,19 @@ import IconArrowNarrowUp from "@/assets/icons/IconArrowNarrowUp.svg";
     }
 
     let ticking = false;
-    document.addEventListener("scroll", () => {
-      if (!ticking) {
-        window.requestAnimationFrame(() => {
-          handleScroll();
-          ticking = false;
-        });
-        ticking = true;
-      }
-    });
+    document.addEventListener(
+      "scroll",
+      () => {
+        if (!ticking) {
+          window.requestAnimationFrame(() => {
+            handleScroll();
+            ticking = false;
+          });
+          ticking = true;
+        }
+      },
+      { passive: true, signal },
+    );
   }
   backToTop();
 </script>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,5 +1,4 @@
 ---
-import { slugifyStr } from "@/utils/slugify";
 import type { CollectionEntry } from "astro:content";
 import { getPath } from "@/utils/getPath";
 import dayjs from "dayjs";
@@ -25,18 +24,22 @@ const {
   body,
 } = Astro.props;
 
-const { title, description, pubDatetime, modDatetime, timezone: postTimezone } =
-  data;
+const {
+  title,
+  description,
+  pubDatetime,
+  modDatetime,
+  timezone: postTimezone,
+} = data;
 
 const isModified = modDatetime && modDatetime > pubDatetime;
 const datetime = dayjs(isModified ? modDatetime : pubDatetime).tz(
-  postTimezone || SITE.timezone
+  postTimezone || SITE.timezone,
 );
 const date = datetime.format("MMM D, YYYY");
 const readingTime = formatReadingTime(getReadingTime(body ?? ""));
 
 const headerProps = {
-  style: { viewTransitionName: slugifyStr(title) },
   class:
     "font-medium tracking-tight text-foreground transition-colors group-hover:text-accent",
 };
@@ -62,7 +65,9 @@ const headerProps = {
   </a>
   {
     showDescription && description && (
-      <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{description}</p>
+      <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+        {description}
+      </p>
     )
   }
 </li>

--- a/src/components/HomeGraphic.astro
+++ b/src/components/HomeGraphic.astro
@@ -1,0 +1,64 @@
+<figure class="home-graphic" aria-hidden="true">
+  <svg viewBox="0 0 420 260" focusable="false" class="h-auto w-full">
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path
+        class="text-border"
+        stroke-width="1"
+        d="M62 210h286M86 48h216c14 0 25 11 25 25v112c0 14-11 25-25 25H86c-14 0-25-11-25-25V73c0-14 11-25 25-25Z"
+      ></path>
+      <path
+        class="text-muted-foreground/45"
+        stroke-width="1"
+        d="M101 82h98M101 109h172M101 136h136M101 163h78"></path>
+      <path
+        class="text-foreground"
+        stroke-width="1.5"
+        d="M236 82h42M236 109h28M236 136h52"></path>
+      <path
+        class="text-accent"
+        stroke-width="1.5"
+        d="M314 79l35-20M314 181l35 20M339 67v126"></path>
+      <circle
+        class="text-accent"
+        cx="349"
+        cy="59"
+        r="5"
+        fill="currentColor"
+        stroke="none"></circle>
+      <circle
+        class="text-accent"
+        cx="349"
+        cy="201"
+        r="5"
+        fill="currentColor"
+        stroke="none"></circle>
+      <path
+        class="text-muted-foreground/50"
+        stroke-width="1"
+        d="M74 226c43-8 70-8 109 0s69 8 112 0"></path>
+      <path
+        class="text-foreground"
+        stroke-width="1.5"
+        d="M147 183l20-47 20 47M157 161h20"></path>
+      <path class="text-accent" stroke-width="2" d="M97 190h34"></path>
+      <path
+        class="text-muted-foreground/40"
+        stroke-width="1"
+        d="M318 103l24 14-24 14M342 145h-35"></path>
+    </g>
+  </svg>
+</figure>
+
+<style>
+  .home-graphic {
+    margin: 0;
+    aspect-ratio: 21 / 13;
+    inline-size: min(100%, 22rem);
+    color: var(--foreground);
+  }
+</style>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -70,7 +70,7 @@ const allPosts = posts.map(({ data: { title }, id, filePath }) => ({
   filePath,
 }));
 
-const currentPostIndex = allPosts.findIndex(a => a.id === post.id);
+const currentPostIndex = allPosts.findIndex((a) => a.id === post.id);
 
 const prevPost = currentPostIndex !== 0 ? allPosts[currentPostIndex - 1] : null;
 const nextPost =
@@ -85,16 +85,15 @@ const nextPost =
     data-pagefind-body
   >
     <div id="post-layout" class="lg:gap-12">
-      <nav
-        id="toc"
-        class="hidden lg:block"
-        aria-label="Table of contents"
-      >
+      <nav id="toc" class="hidden lg:block" aria-label="Table of contents">
         <div class="sticky top-24">
-          <p class="mb-3 text-xs font-medium tracking-widest text-muted-foreground uppercase">
+          <p
+            class="mb-3 text-xs font-medium tracking-widest text-muted-foreground uppercase"
+          >
             On this page
           </p>
-          <ol id="toc-list" class="space-y-2 text-sm text-muted-foreground"></ol>
+          <ol id="toc-list" class="space-y-2 text-sm text-muted-foreground">
+          </ol>
         </div>
       </nav>
 
@@ -107,20 +106,20 @@ const nextPost =
           )
         }
         <h1
-          transition:name={slugifyStr(title)}
           class="mt-3 font-serif text-[clamp(1.75rem,3vw+1rem,2.5rem)] leading-tight font-medium tracking-tight"
         >
           {title}
         </h1>
-        <div class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+        <div
+          class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground"
+        >
           <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" />
           <span aria-hidden="true">·</span>
           <span>{readingTime}</span>
           <span
             aria-hidden="true"
-            class:list={[
-              { hidden: !SITE.editPost.enabled || hideEditPost },
-            ]}>·</span
+            class:list={[{ hidden: !SITE.editPost.enabled || hideEditPost }]}
+            >·</span
           >
           <EditPost {hideEditPost} {post} />
         </div>
@@ -138,14 +137,19 @@ const nextPost =
           {
             tags.length > 0 && (
               <ul class="mb-8 flex flex-wrap gap-2">
-                {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
+                {tags.map((tag) => (
+                  <Tag tag={slugifyStr(tag)} tagName={tag} />
+                ))}
               </ul>
             )
           }
 
           <ShareLinks />
 
-          <div data-pagefind-ignore class="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <div
+            data-pagefind-ignore
+            class="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2"
+          >
             {
               prevPost && (
                 <a
@@ -187,163 +191,187 @@ const nextPost =
 </Layout>
 
 <script is:inline data-astro-rerun>
-  document.documentElement.setAttribute("data-reading-mode", "");
+  (() => {
+    const postPageController = new AbortController();
+    const { signal } = postPageController;
 
-  function initReadingMode() {
-    const header = document.querySelector("header");
-    if (!header) return;
+    function cleanupPostPage() {
+      postPageController.abort();
+      document.documentElement.removeAttribute("data-reading-mode");
+      document.querySelector(".progress-container")?.remove();
+    }
 
-    let ticking = false;
-    const onScroll = () => {
-      if (!ticking) {
+    document.addEventListener("astro:before-swap", cleanupPostPage, {
+      once: true,
+    });
+
+    document.documentElement.setAttribute("data-reading-mode", "");
+
+    function initReadingMode() {
+      const header = document.querySelector("header");
+      if (!header) return;
+
+      let ticking = false;
+      const onScroll = () => {
+        if (!ticking) {
+          window.requestAnimationFrame(() => {
+            header.classList.toggle("is-scrolled", window.scrollY > 80);
+            ticking = false;
+          });
+          ticking = true;
+        }
+      };
+
+      onScroll();
+      document.addEventListener("scroll", onScroll, { passive: true, signal });
+    }
+
+    function createProgressBar() {
+      if (document.querySelector(".progress-container")) return;
+
+      const progressContainer = document.createElement("div");
+      progressContainer.className =
+        "progress-container fixed top-0 z-50 h-px w-full bg-border";
+
+      const progressBar = document.createElement("div");
+      progressBar.className = "progress-bar h-px w-0 bg-accent/60";
+      progressBar.id = "myBar";
+
+      progressContainer.appendChild(progressBar);
+      document.body.appendChild(progressContainer);
+    }
+
+    function updateScrollProgress() {
+      let ticking = false;
+      const onScroll = () => {
+        if (ticking) return;
+
         window.requestAnimationFrame(() => {
-          header.classList.toggle("is-scrolled", window.scrollY > 80);
+          const winScroll =
+            document.body.scrollTop || document.documentElement.scrollTop;
+          const height =
+            document.documentElement.scrollHeight -
+            document.documentElement.clientHeight;
+          const scrolled = height > 0 ? (winScroll / height) * 100 : 0;
+          const myBar = document.getElementById("myBar");
+          if (myBar) myBar.style.width = scrolled + "%";
           ticking = false;
         });
         ticking = true;
-      }
-    };
+      };
 
-    onScroll();
-    document.addEventListener("scroll", onScroll, { passive: true });
-  }
-
-  function createProgressBar() {
-    if (document.querySelector(".progress-container")) return;
-
-    const progressContainer = document.createElement("div");
-    progressContainer.className =
-      "progress-container fixed top-0 z-50 h-px w-full bg-border";
-
-    const progressBar = document.createElement("div");
-    progressBar.className = "progress-bar h-px w-0 bg-accent/60";
-    progressBar.id = "myBar";
-
-    progressContainer.appendChild(progressBar);
-    document.body.appendChild(progressContainer);
-  }
-
-  function updateScrollProgress() {
-    document.addEventListener("scroll", () => {
-      const winScroll =
-        document.body.scrollTop || document.documentElement.scrollTop;
-      const height =
-        document.documentElement.scrollHeight -
-        document.documentElement.clientHeight;
-      const scrolled = (winScroll / height) * 100;
-      const myBar = document.getElementById("myBar");
-      if (myBar) myBar.style.width = scrolled + "%";
-    });
-  }
-
-  function buildToc() {
-    const article = document.querySelector("#article");
-    const toc = document.querySelector("#toc");
-    const tocList = document.querySelector("#toc-list");
-    const layout = document.querySelector("#post-layout");
-    if (!article || !toc || !tocList || !layout) return;
-
-    tocList.innerHTML = "";
-    const headings = Array.from(article.querySelectorAll("h2, h3"));
-
-    if (headings.length < 3) {
-      toc.classList.add("hidden");
-      layout.classList.remove("has-toc");
-      return;
+      onScroll();
+      document.addEventListener("scroll", onScroll, { passive: true, signal });
     }
 
-    toc.classList.remove("hidden");
-    layout.classList.add("has-toc");
+    function buildToc() {
+      const article = document.querySelector("#article");
+      const toc = document.querySelector("#toc");
+      const tocList = document.querySelector("#toc-list");
+      const layout = document.querySelector("#post-layout");
+      if (!article || !toc || !tocList || !layout) return;
 
-    for (const heading of headings) {
-      if (!heading.id) {
-        heading.id =
-          heading.textContent
-            ?.trim()
-            .toLowerCase()
-            .replace(/[^\w\s-]/g, "")
-            .replace(/\s+/g, "-") ?? "";
+      tocList.innerHTML = "";
+      const headings = Array.from(article.querySelectorAll("h2, h3"));
+
+      if (headings.length < 3) {
+        toc.classList.add("hidden");
+        layout.classList.remove("has-toc");
+        return;
       }
 
-      const item = document.createElement("li");
-      const link = document.createElement("a");
-      link.href = `#${heading.id}`;
-      link.textContent = heading.textContent ?? "";
-      link.className =
-        heading.tagName === "H3"
-          ? "block ps-3 transition-colors hover:text-accent"
-          : "block transition-colors hover:text-accent";
+      toc.classList.remove("hidden");
+      layout.classList.add("has-toc");
 
-      item.appendChild(link);
-      tocList.appendChild(item);
+      for (const heading of headings) {
+        if (!heading.id) {
+          heading.id =
+            heading.textContent
+              ?.trim()
+              .toLowerCase()
+              .replace(/[^\w\s-]/g, "")
+              .replace(/\s+/g, "-") ?? "";
+        }
+
+        const item = document.createElement("li");
+        const link = document.createElement("a");
+        link.href = `#${heading.id}`;
+        link.textContent = heading.textContent ?? "";
+        link.className =
+          heading.tagName === "H3"
+            ? "block ps-3 transition-colors hover:text-accent"
+            : "block transition-colors hover:text-accent";
+
+        item.appendChild(link);
+        tocList.appendChild(item);
+      }
     }
-  }
 
-  function addHeadingLinks() {
-    const headings = Array.from(
-      document.querySelectorAll("#article h2, #article h3, #article h4")
-    );
-    for (const heading of headings) {
-      heading.classList.add("group");
-      const link = document.createElement("a");
-      link.className =
-        "heading-link ms-2 font-sans text-sm no-underline opacity-0 transition-opacity group-hover:opacity-60 focus:opacity-60";
-      link.href = `#${heading.id}`;
-      link.innerText = "#";
-      heading.appendChild(link);
+    function addHeadingLinks() {
+      const headings = Array.from(
+        document.querySelectorAll("#article h2, #article h3, #article h4"),
+      );
+      for (const heading of headings) {
+        heading.classList.add("group");
+        const link = document.createElement("a");
+        link.className =
+          "heading-link ms-2 font-sans text-sm no-underline opacity-0 transition-opacity group-hover:opacity-60 focus:opacity-60";
+        link.href = `#${heading.id}`;
+        link.innerText = "#";
+        heading.appendChild(link);
+      }
     }
-  }
 
-  function attachCopyButtons() {
-    const copyButtonLabel = "Copy";
-    const codeBlocks = Array.from(document.querySelectorAll("#article pre"));
+    function attachCopyButtons() {
+      const copyButtonLabel = "Copy";
+      const codeBlocks = Array.from(document.querySelectorAll("#article pre"));
 
-    for (const codeBlock of codeBlocks) {
-      const computedStyle = getComputedStyle(codeBlock);
-      const hasFileNameOffset =
-        computedStyle.getPropertyValue("--file-name-offset").trim() !== "";
-      const topClass = hasFileNameOffset
-        ? "top-(--file-name-offset)"
-        : "-top-3";
+      for (const codeBlock of codeBlocks) {
+        const computedStyle = getComputedStyle(codeBlock);
+        const hasFileNameOffset =
+          computedStyle.getPropertyValue("--file-name-offset").trim() !== "";
+        const topClass = hasFileNameOffset
+          ? "top-(--file-name-offset)"
+          : "-top-3";
 
-      const wrapper = document.createElement("div");
-      wrapper.style.position = "relative";
+        const wrapper = document.createElement("div");
+        wrapper.style.position = "relative";
 
-      const copyButton = document.createElement("button");
-      copyButton.className = `copy-code absolute end-3 ${topClass} rounded border border-border bg-muted px-2 py-1 font-sans text-xs leading-4 font-medium text-foreground`;
-      copyButton.innerHTML = copyButtonLabel;
-      codeBlock.setAttribute("tabindex", "0");
-      codeBlock.appendChild(copyButton);
+        const copyButton = document.createElement("button");
+        copyButton.className = `copy-code absolute end-3 ${topClass} rounded border border-border bg-muted px-2 py-1 font-sans text-xs leading-4 font-medium text-foreground`;
+        copyButton.innerHTML = copyButtonLabel;
+        codeBlock.setAttribute("tabindex", "0");
+        codeBlock.appendChild(copyButton);
 
-      codeBlock?.parentNode?.insertBefore(wrapper, codeBlock);
-      wrapper.appendChild(codeBlock);
+        codeBlock?.parentNode?.insertBefore(wrapper, codeBlock);
+        wrapper.appendChild(codeBlock);
 
-      copyButton.addEventListener("click", async () => {
-        const code = codeBlock.querySelector("code");
-        await navigator.clipboard.writeText(code?.innerText ?? "");
-        window.posthog?.capture("code_copied", {
-          post_title: document.querySelector("h1")?.innerText,
-          post_url: window.location.pathname,
-        });
-        copyButton.innerText = "Copied";
-        setTimeout(() => {
-          copyButton.innerText = copyButtonLabel;
-        }, 700);
-      });
+        copyButton.addEventListener(
+          "click",
+          async () => {
+            const code = codeBlock.querySelector("code");
+            await navigator.clipboard.writeText(code?.innerText ?? "");
+            window.posthog?.capture("code_copied", {
+              post_title: document.querySelector("h1")?.innerText,
+              post_url: window.location.pathname,
+            });
+            copyButton.innerText = "Copied";
+            setTimeout(() => {
+              copyButton.innerText = copyButtonLabel;
+            }, 700);
+          },
+          { signal },
+        );
+      }
     }
-  }
 
-  createProgressBar();
-  updateScrollProgress();
-  initReadingMode();
-  buildToc();
-  addHeadingLinks();
-  attachCopyButtons();
-
-  document.addEventListener("astro:after-swap", () => {
-    document.documentElement.setAttribute("data-reading-mode", "");
-    window.scrollTo({ left: 0, top: 0, behavior: "instant" });
-  });
+    createProgressBar();
+    updateScrollProgress();
+    initReadingMode();
+    buildToc();
+    addHeadingLinks();
+    attachCopyButtons();
+  })();
 </script>
 
 <script is:inline define:vars={{ postTitle: title, postTags: tags }}>
@@ -351,11 +379,5 @@ const nextPost =
     post_title: postTitle,
     post_tags: postTags,
     post_url: window.location.pathname,
-  });
-</script>
-
-<script is:inline>
-  document.addEventListener("astro:before-swap", () => {
-    document.documentElement.removeAttribute("data-reading-mode");
   });
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import Footer from "@/components/Footer.astro";
 import Socials from "@/components/Socials.astro";
 import LinkButton from "@/components/LinkButton.astro";
 import Card from "@/components/Card.astro";
+import HomeGraphic from "@/components/HomeGraphic.astro";
 import getSortedPosts from "@/utils/getSortedPosts";
 import IconRss from "@/assets/icons/IconRss.svg";
 import IconArrowRight from "@/assets/icons/IconArrowRight.svg";
@@ -22,29 +23,37 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
 <Layout>
   <Header />
   <main id="main-content" data-layout="index">
-    <section id="hero" class="px-6 pt-12 pb-10">
-      <h1 class="sr-only">{SITE.title}</h1>
-      <p class="max-w-2xl text-lg leading-relaxed text-muted-foreground">
-        Welcome to my words.
-      </p>
-      {
-        SOCIALS.length > 0 && (
-          <div class="mt-8 flex items-center gap-4">
-            <Socials />
-            <a
-              target="_blank"
-              href="/rss.xml"
-              class="text-muted-foreground transition-colors hover:text-foreground"
-              aria-label="rss feed"
-              title="RSS Feed"
-              onclick="window.posthog?.capture('rss_feed_clicked')"
-            >
-              <IconRss width={16} height={16} class="stroke-current" />
-              <span class="sr-only">RSS Feed</span>
-            </a>
-          </div>
-        )
-      }
+    <section
+      id="hero"
+      class="grid items-center gap-8 px-6 pt-12 pb-10 sm:grid-cols-[minmax(0,1fr)_minmax(14rem,22rem)]"
+    >
+      <div class="min-w-0">
+        <h1 class="sr-only">{SITE.title}</h1>
+        <p class="max-w-2xl text-lg leading-relaxed text-muted-foreground">
+          Welcome to my words.
+        </p>
+        {
+          SOCIALS.length > 0 && (
+            <div class="mt-8 flex items-center gap-4">
+              <Socials />
+              <a
+                target="_blank"
+                href="/rss.xml"
+                class="text-muted-foreground transition-colors hover:text-foreground"
+                aria-label="rss feed"
+                title="RSS Feed"
+                onclick="window.posthog?.capture('rss_feed_clicked')"
+              >
+                <IconRss width={16} height={16} class="stroke-current" />
+                <span class="sr-only">RSS Feed</span>
+              </a>
+            </div>
+          )
+        }
+      </div>
+      <div class="flex justify-start sm:justify-end">
+        <HomeGraphic />
+      </div>
     </section>
 
     {
@@ -54,7 +63,7 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
             Featured
           </h2>
           <ul>
-            {featuredPosts.map(data => (
+            {featuredPosts.map((data) => (
               <Card variant="h3" {...data} />
             ))}
           </ul>
@@ -71,7 +80,7 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
           <ul>
             {recentPosts.map(
               (data, index) =>
-                index < SITE.postPerIndex && <Card variant="h3" {...data} />
+                index < SITE.postPerIndex && <Card variant="h3" {...data} />,
             )}
           </ul>
         </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,7 +39,7 @@ html[data-theme="dark"] {
     scrollbar-color: var(--color-border) transparent;
   }
   html {
-    @apply overflow-y-scroll scroll-smooth;
+    @apply overflow-y-scroll;
   }
   body {
     @apply flex min-h-svh flex-col bg-background font-sans text-foreground antialiased selection:bg-accent/20 selection:text-foreground;


### PR DESCRIPTION
## What changed

- Added a lightweight custom inline SVG graphic to the homepage hero.
- Cleaned up post-page navigation behavior by scoping scroll/progress/listener setup to the post page lifecycle.
- Removed the named title view transition between post headings and homepage cards.
- Removed always-on global smooth scrolling so navigation scroll restoration is not fighting CSS smooth scroll.

## Why

The homepage needed a more finished custom visual signal, and navigation from posts back to the homepage felt choppy because post-only behavior could persist across Astro client-side transitions.

## Validation

- `node_modules/.bin/astro check` passes with only the known `src/constants.ts` unused-icon hints.
- `node_modules/.bin/astro build` passes with network access for OG font fetching.
- `node_modules/.bin/pagefind --site dist` passes.
- `node --test tests/blog-posts.test.mjs tests/build-output.test.mjs` passes.
- `node_modules/.bin/eslint .` still fails only on the pre-existing unused icon imports in `src/constants.ts`.